### PR TITLE
Adds verbose logging on worker thread shutdown when parent changes

### DIFF
--- a/gunicorn/workers/_gaiohttp.py
+++ b/gunicorn/workers/_gaiohttp.py
@@ -100,7 +100,10 @@ class AiohttpWorker(base.Worker):
 
                 if (self.alive and
                         pid == os.getpid() and self.ppid != os.getppid()):
-                    self.log.info("Parent changed, shutting down: %s", self)
+                    self.log.info("Parent changed, shutting down: %s self.ppid=%s os.getppid()=%s",
+                                  self,
+                                  self.ppid,
+                                  os.getppid())
                     self.alive = False
 
                 # stop accepting requests

--- a/gunicorn/workers/gthread.py
+++ b/gunicorn/workers/gthread.py
@@ -191,7 +191,10 @@ class ThreadWorker(base.Worker):
     def is_parent_alive(self):
         # If our parent changed then we shut down.
         if self.ppid != os.getppid():
-            self.log.info("Parent changed, shutting down: %s", self)
+            self.log.info("Parent changed, shutting down: %s self.ppid=%s os.getppid()=%s",
+                          self,
+                          self.ppid,
+                          os.getppid())
             return False
         return True
 

--- a/gunicorn/workers/sync.py
+++ b/gunicorn/workers/sync.py
@@ -51,7 +51,10 @@ class SyncWorker(base.Worker):
     def is_parent_alive(self):
         # If our parent changed then we shut down.
         if self.ppid != os.getppid():
-            self.log.info("Parent changed, shutting down: %s", self)
+            self.log.info("Parent changed, shutting down: %s self.ppid=%s os.getppid()=%s",
+                          self,
+                          self.ppid,
+                          os.getppid())
             return False
         return True
 


### PR DESCRIPTION
Adding this feature to debug a problem where gunicorn worker threads are shutting down only when a docker image with flask + gunicorn in it runs in AWS infrastructure